### PR TITLE
Update map.sh.new

### DIFF
--- a/map.sh.new
+++ b/map.sh.new
@@ -187,6 +187,9 @@ proto_map_setup() {
 #------------------------------------
             #MODIFICATION 2: Create mape table
 #------------------------------------
+            if nft list tables | grep -q "table inet mape"; then                                               
+                nft delete table inet mape                                                                             
+            fi                                                                                                         
             nft add table inet mape
             nft add chain inet mape srcnat {type nat hook postrouting priority 0\; policy accept\; }
 #------------------------------------


### PR DESCRIPTION
Delete mape table if it exists before creating mape table, to prevent double table creation.
@fakemanhk 
Resolves https://github.com/fakemanhk/openwrt-jp-ipoe/issues/30